### PR TITLE
Add SOCIAL_META property to env and compose

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,4 @@ GA_TRACKING_ID=1 # Google Analytics Measurement ID/gtag
 CLIENT_HEADER=CF-Connecting-IP # CF-Connecting-IP is used for Cloudflare to get the actual client IP address for viwer stats. For Non-Cloudflare you may need to change to X-Forwarded-For or X-Real-IP
 SENGRID_KEY=   # Sendgrid key
 GITHUB_PAT= # GitHub Personal Authentication Token
+SOCIAL_META=<meta property='og:url' content='https://remotefalcon.com/'/><meta property='og:title' content='Remote Falcon'/><meta property='og:description' content='Create a custom website where viewers can request or vote for sequences to watch on your light show.'/><meta property='og:image' content='https://remotefalcon.com/jukebox.png'/>

--- a/compose.yaml
+++ b/compose.yaml
@@ -98,6 +98,7 @@ services:
         - PUBLIC_POSTHOG_KEY=${PUBLIC_POSTHOG_KEY}
         - GA_TRACKING_ID=${GA_TRACKING_ID}
         - HOSTNAME_PARTS=${HOSTNAME_PARTS}
+        - SOCIAL_META=${SOCIAL_META}
     image: ui
     container_name: ui
     restart: always


### PR DESCRIPTION
Added the SOCIAL_META property to the env and to docker compose.

Feel free to integrate this in your script however you see fit. Just wanted to get it added so hosters can start using it, even if modified manually.