### PR TITLE
Add sequence limit arg

### DIFF
--- a/no-published-ports/compose.yaml
+++ b/no-published-ports/compose.yaml
@@ -40,6 +40,7 @@ services:
       - server.port=8083
       - spring.data.mongodb.uri=mongodb://root:root@mongo:27017/remote-falcon?authSource=admin
       - server.servlet.context-path=/remote-falcon-plugins-api
+      - sequence-limit=200
     depends_on:
       - mongo
   control-panel:

--- a/published-ports/compose.yaml
+++ b/published-ports/compose.yaml
@@ -42,6 +42,7 @@ services:
       - server.port=8083
       - spring.data.mongodb.uri=mongodb://root:root@mongo:27017/remote-falcon?authSource=admin
       - server.servlet.context-path=/remote-falcon-plugins-api
+      - sequence-limit=200
     depends_on:
       - mongo
   control-panel:


### PR DESCRIPTION
Adding a sequence limit argument to the compose files so self-hosters can override the limit if they choose. Will be adding an override in the plugin as well.